### PR TITLE
OPT (#54): Removed id as param in endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,8 +52,14 @@ Only one of the 2 parameters can be specified.
 
 **Example Request:**
 
+- Get recipe by owner
 ```sh
 GET /api/recipes/personal?owner=tm
+```
+
+- Get recipe by id
+```sh
+GET /api/recipes/personal/1
 ```
 
 **Example Response:**

--- a/README.md
+++ b/README.md
@@ -54,12 +54,7 @@ Only one of the 2 parameters can be specified.
 
 - Get recipe by owner
 ```sh
-GET /api/recipes/personal?owner=tm
-```
-
-- Get recipe by id
-```sh
-GET /api/recipes/personal/1
+  GET /api/recipes/personal?owner=tm
 ```
 
 **Example Response:**
@@ -87,8 +82,9 @@ GET /api/recipes/personal/1
 
 **Example Request:**
 
+- Get recipe by id
 ```sh
-GET /api/recipes/personal?id=1
+  GET /api/recipes/personal/1
 ```
 
 **Example Response:**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The application should now be running on `http://localhost:8080`.
 **Method:** `GET`
 
 **Description:** This endpoint retrieves personal recipes. If the `owner` parameter is provided, it filters recipes by the specified owner. If the `owner` parameter is not provided, it returns all recipes.   
-If the `id` parameter is provided, it filters recipes by the specified id. If the `id` parameter is not provided, it returns all recipes.   
+The `id` path is provided after `persona/{id}`, it filters recipes by the specified id. If the `id` path is not provided, it returns all recipes.   
 Only one of the 2 parameters can be specified.   
 
 **Parameters:**

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The application should now be running on `http://localhost:8080`.
 **Method:** `GET`
 
 **Description:** This endpoint retrieves personal recipes. If the `owner` parameter is provided, it filters recipes by the specified owner. If the `owner` parameter is not provided, it returns all recipes.   
-The `id` path is provided after `persona/{id}`, it filters recipes by the specified id. If the `id` path is not provided, it returns all recipes.   
+The `id` path is provided after `personal/{id}`, it filters recipes by the specified id. If the `id` path is not provided, it returns all recipes.   
 Only one of the 2 parameters can be specified.   
 
 **Parameters:**

--- a/src/main/java/com/example/cooking_lab_personal_recipe_api/api/controller/RecipeController.java
+++ b/src/main/java/com/example/cooking_lab_personal_recipe_api/api/controller/RecipeController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -22,18 +23,21 @@ public class RecipeController {
 
     @CrossOrigin(origins = {"http://localhost:3000", "https://cooking-lab.netlify.app"})
     @GetMapping("/api/recipes/personal")
-    public List<Recipe> getRecipe(@RequestParam(required = false) String owner, @RequestParam(required = false) Integer id) {
-        if (id != null && owner != null) {
-            throw new IllegalArgumentException("Please specify only one parameter: 'id' or 'owner', not both.");
-        }
-
-        if (id != null) {
-            return recipeService.getRecipeById(id);
-        } else if (owner != null && !owner.isEmpty()) {
+    public List<Recipe> getRecipe(@RequestParam(required = false) String owner) {
+        if (owner != null && !owner.isEmpty()) {
             return recipeService.getRecipeByOwner(owner);
         } else {
             return recipeService.getAllRecipes();
         }
     }
 
+    @CrossOrigin(origins = {"http://localhost:3000", "https://cooking-lab.netlify.app"})
+    @GetMapping("/api/recipes/personal/{id}")
+    public List<Recipe> getRecipeId(@PathVariable Integer id) {
+        if (id != null) {
+            return recipeService.getRecipeById(id);
+        } else {
+            return recipeService.getAllRecipes();
+        }
+    }
 }

--- a/src/test/java/com/example/cooking_lab_personal_recipe_api/api/controller/RecipeControllerTest.java
+++ b/src/test/java/com/example/cooking_lab_personal_recipe_api/api/controller/RecipeControllerTest.java
@@ -26,19 +26,11 @@ public class RecipeControllerTest {
     }
 
     @Test
-    public void testGetRecipeWithBothIdAndOwner() {
-        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
-            recipeController.getRecipe("owner", 1);
-        });
-        assertEquals("Please specify only one parameter: 'id' or 'owner', not both.", exception.getMessage());
-    }
-
-    @Test
     public void testGetRecipeWithId() {
         Recipe recipe = new Recipe();
         when(recipeService.getRecipeById(1)).thenReturn(Collections.singletonList(recipe));
 
-        List<Recipe> result = recipeController.getRecipe(null, 1);
+        List<Recipe> result = recipeController.getRecipeId(1);
         assertEquals(1, result.size());
         assertEquals(recipe, result.get(0));
     }
@@ -48,7 +40,7 @@ public class RecipeControllerTest {
         Recipe recipe = new Recipe();
         when(recipeService.getRecipeByOwner("owner")).thenReturn(Collections.singletonList(recipe));
 
-        List<Recipe> result = recipeController.getRecipe("owner", null);
+        List<Recipe> result = recipeController.getRecipe("owner");
         assertEquals(1, result.size());
         assertEquals(recipe, result.get(0));
     }
@@ -58,7 +50,17 @@ public class RecipeControllerTest {
         Recipe recipe = new Recipe();
         when(recipeService.getAllRecipes()).thenReturn(Collections.singletonList(recipe));
 
-        List<Recipe> result = recipeController.getRecipe(null, null);
+        List<Recipe> result = recipeController.getRecipe(null);
+        assertEquals(1, result.size());
+        assertEquals(recipe, result.get(0));
+    }
+
+    @Test
+    public void testGetRecipeIdWithNoParams() {
+        Recipe recipe = new Recipe();
+        when(recipeService.getAllRecipes()).thenReturn(Collections.singletonList(recipe));
+
+        List<Recipe> result = recipeController.getRecipeId(null);
         assertEquals(1, result.size());
         assertEquals(recipe, result.get(0));
     }


### PR DESCRIPTION
- Removed id from getRecipe()
- Created another endpoint function with the name of getRecipeId
- Updated RecipeControllerTest to have 100% coverage

Screenshot of testing param for id:
<img width="863" alt="Screenshot 2024-11-28 at 1 29 33 PM" src="https://github.com/user-attachments/assets/ec7f1ab6-d6a0-4df7-96da-de94c4ee01a7">

Screenshot of testing for owner:
<img width="855" alt="Screenshot 2024-11-28 at 1 30 27 PM" src="https://github.com/user-attachments/assets/94dcb3bf-495b-4a99-9265-6329dcaedeb3">

Screenshot of testing both owner and id that should not work:
<img width="787" alt="Screenshot 2024-11-28 at 1 30 52 PM" src="https://github.com/user-attachments/assets/41e87a85-47a6-45bb-aa00-8bc9d2292096">

Screenshot of 100% testing coverage:
<img width="914" alt="Screenshot 2024-11-28 at 1 31 38 PM" src="https://github.com/user-attachments/assets/21d8f45b-882c-4583-8801-787924b4408a">

